### PR TITLE
Updated the version of ConPagnon: v2.0.1: 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ MAINTAINER = 'Dhaif BEKHA'
 MAINTAINER_EMAIL = 'dhaif@dhaifbekha.com'
 URL = 'https://conpagnon.github.io/conpagnon/'
 LICENSE = 'new BSD'
-DOWNLOAD_URL = 'https://github.com/ConPagnon/conpagnon/archive/v2.0.0.tar.gz'
+DOWNLOAD_URL = 'https://github.com/ConPagnon/conpagnon/archive/v2.0.1.tar.gz'
 VERSION = '2.0.1'
 
 


### PR DESCRIPTION
fix URL in the download_url field for PiPy