### PR TITLE
Prepare 2.0.11:

### DIFF
--- a/conpagnon/__init__.py
+++ b/conpagnon/__init__.py
@@ -43,7 +43,7 @@ utils                   --- Utilities for saving and loading object,
 import sys
 import warnings
 
-from .version import _check_module_dependencies, __version__
+from conpagnon.version import _check_module_dependencies, __version__
 
 
 def _py35_deprecation_warning():

--- a/conpagnon/version.py
+++ b/conpagnon/version.py
@@ -12,7 +12,7 @@ ConPagnon version, dependencies checking.
 # X.YrcN # Release Candidate
 # X.Y # Final release
 
-__version__ = '2.0.10'
+__version__ = '2.0.11'
 
 _CONPAGNON_INSTALL_MSG = 'See %s for installation information.' % (
     'https://conpagnon.github.io/conpagnon/install.html')

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ MAINTAINER = 'Dhaif BEKHA'
 MAINTAINER_EMAIL = 'dhaif@dhaifbekha.com'
 URL = 'https://conpagnon.github.io/conpagnon/'
 LICENSE = 'new BSD'
-DOWNLOAD_URL = 'https://github.com/ConPagnon/conpagnon/archive/v2.0.10.tar.gz'
+DOWNLOAD_URL = 'https://github.com/ConPagnon/conpagnon/archive/v2.0.11.tar.gz'
 VERSION = _VERSION_GLOBALS['__version__']
 
 


### PR DESCRIPTION
Complete the conpagnon __init__.py, with __version__ import,
full docstrings containing list of modules. Check Python version,
no less than 3.6, accordingly with the required version of other
dependencies.